### PR TITLE
feat(wedding): animated split-screen invitation with theme switch, event timeline & notifications

### DIFF
--- a/src/app/wedding/wedding-page.tsx
+++ b/src/app/wedding/wedding-page.tsx
@@ -8,6 +8,7 @@ import { useEffect, useState, type CSSProperties } from "react";
 import { BlurFade } from "@/components/ui/blur-fade";
 import { AuroraBackground } from "@/components/ui/aurora-background";
 import { Crackers } from "@/components/ui/crackers";
+import { ProjectBanner } from "@/components/ui/project-banner";
 
 const EVENTS = [
   {
@@ -259,6 +260,27 @@ html.wd-dark, html.wd-dark body { background-color: #060608 !important; color-sc
 }
 /* Aurora sits behind everything */
 .aurora-bg { position: fixed; inset: 0; z-index: -1; }
+
+/* next-event banner — sits above the footer */
+.next-banner-wrap {
+  display: flex;
+  justify-content: center;
+  padding: 8px 16px 0;
+}
+.next-banner {
+  max-width: 92vw;
+  background: var(--bg) !important;
+  color: var(--ink) !important;
+  border-color: var(--line) !important;
+  box-shadow: 0 8px 26px rgba(0, 0, 0, 0.10) !important;
+  font-family: var(--font-montserrat), sans-serif;
+  font-size: 0.66rem !important;
+  letter-spacing: 0.04em;
+  animation: notif-in 0.4s ease;
+}
+.next-banner a { color: var(--ink); }
+.next-banner .nb-ico { display: inline-flex; color: var(--rose); }
+.next-banner .nb-ico svg { width: 13px; height: 13px; }
 /* guarantee the aurora goes dark with the wedding theme (inline = never stale-cached) */
 html.wd-dark .aurora-bg { background-color: #060608 !important; }
 html.wd-dark .aurora-bg > div > div { opacity: 0.12 !important; filter: none !important; }
@@ -616,6 +638,8 @@ export default function WeddingPage() {
   const notifs = now ? buildNotifs(now) : [];
   const hasUrgent = notifs.some((n) => n.urgent);
   const isCelebrationDay = now > 0 && CELEBRATION_DAYS.has(istDayStr(now));
+  // The soonest event that hasn't concluded (happening now / upcoming).
+  const nextUp = notifs.find((n) => !n.id.endsWith("-completed"));
 
   useEffect(() => {
     // Always load in the light theme; dark is opt-in via the toggle for this session.
@@ -778,7 +802,18 @@ export default function WeddingPage() {
           </div>
         </div>
       </div>
-
+{/* Bottom banner — surfaces the next event that's coming up */}
+      {nextUp && (
+        <div className="next-banner-wrap">
+          <ProjectBanner
+            className="next-banner"
+            variant="default"
+            icon={<span className="nb-ico">{ICONS.heartFilled}</span>}
+            label={nextUp.title}
+            callToAction={{ label: "Get Directions", href: nextUp.mapsUrl }}
+          />
+        </div>
+      )}
       {/* FOOTER */}
       <footer className="foot">
         <BlurFade inView delay={0.1}>

--- a/src/components/ui/project-banner.tsx
+++ b/src/components/ui/project-banner.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+type BannerVariant = "default" | "success" | "warning" | "error";
+
+const VARIANTS: Record<BannerVariant, string> = {
+  default: "bg-zinc-100 text-zinc-900 border-zinc-200",
+  success: "bg-emerald-100 text-emerald-900 border-emerald-200",
+  warning: "bg-amber-100 text-amber-900 border-amber-200",
+  error: "bg-rose-100 text-rose-900 border-rose-200",
+};
+
+export interface ProjectBannerProps extends React.HTMLAttributes<HTMLDivElement> {
+  label: React.ReactNode;
+  icon?: React.ReactNode;
+  callToAction?: { label: string; href: string };
+  variant?: BannerVariant;
+}
+
+export function ProjectBanner({
+  label,
+  icon,
+  callToAction,
+  variant = "default",
+  className,
+  ...props
+}: ProjectBannerProps) {
+  const external = callToAction?.href?.startsWith("http");
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-center gap-3 rounded-full border px-4 py-2 text-sm shadow-sm",
+        VARIANTS[variant],
+        className,
+      )}
+      {...props}
+    >
+      <span className="flex items-center gap-2">
+        {icon}
+        <span>{label}</span>
+      </span>
+      {callToAction && (
+        <a
+          href={callToAction.href}
+          target={external ? "_blank" : undefined}
+          rel={external ? "noopener noreferrer" : undefined}
+          className="shrink-0 font-medium underline underline-offset-2 transition-opacity hover:opacity-70"
+        >
+          {callToAction.label}
+        </a>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Wedding invitation page (`/wedding`)

Adds a self-contained, animated wedding invitation for Joan & Angelene — built as a split-screen layout with light/dark theming, an event timeline, live countdown, and time-aware notifications/banner.

### Highlights
- **Split-screen layout** — left: couple, date & live countdown; right: "Wedding Timeline" with hand-drawn line icons connected by a hearts spine. Stacks cleanly on mobile.
- **Theming** — pure-white by default, with a light/dark toggle revealed via a heart/gif-mask **View Transition**. Scoped to a `wd-dark` class so it's fully **independent of the site-wide theme** (never inherits the global dark mode).
- **Animated aurora background** in a warm rose/champagne palette (dimmed to a faint glow in dark mode).
- **Time-aware features (IST-anchored):**
  - 🔔 **Notifications bell** — stage-aware per event: *in N days → today → about to begin (≤3h) → happening now → concluded*; each opens that venue in Google Maps.
  - 🎉 **Crackers/confetti** that burst **only on the celebration days** (11 & 12 July 2026), derived from the event dates.
  - 📍 **Bottom banner** surfacing the next upcoming event with a "Get Directions" CTA.
- **Motion polish** — `BlurFade` entrance animations, hover/touch micro-interactions on timeline rows, beating-heart footer; all respect `prefers-reduced-motion`.

### New reusable components
- `components/ui/blur-fade.tsx`
- `components/ui/aurora-background.tsx`
- `components/ui/crackers.tsx`
- `components/ui/project-banner.tsx`

### Config
- Tailwind: added the `aurora` keyframes/animation and a wedding-scoped `wd-dark` variant.
- Wedding `layout.tsx`: loads display fonts (Caveat, Cinzel, Playfair Display, Pinyon Script, Montserrat) and forces the light theme before paint.